### PR TITLE
Validating uri with proper http:// scheme

### DIFF
--- a/StrutsShell.py
+++ b/StrutsShell.py
@@ -21,6 +21,8 @@ def arguments():
   parser.add_argument('-u','--url', help='Apache Struts vulnerable URL (i.e.: http://www.example.com/test/login.action)')
   args = parser.parse_args()
   debug = args.debug
+  if ('://' not in args.url):	# This will add unvalidated example.com uri with proper http:// scheme 
+	args.url = str('http') + str('://') + str(args.url) 
   if not args.url:
     print errorstring,
     print 'an Apache Struts URL is required (i.e.: http://www.example.com/test/login.action)'


### PR DESCRIPTION
Executing script with only URI wasn't sufficient, in this case, _--url_ argument like _example.com_ will generate error while _http://example.com_ works. 

### Error generator :
```
Traceback (most recent call last):
  File "StrutsShell.py", line 44, in <module>
    main()
  File "StrutsShell.py", line 33, in main
    host = re.findall(r'//([a-zA-Z0-9.]+)/',args.url)[0]
IndexError: list index out of range
```


So as earlier said, It will only execute properly when you provide argument of fully schemed url, so we have to change _example.com_ with _http://example.com_ manually,

Suggested code will convert uri with _http://_ scheme dynamically. 

### With earlier code :

![EalierImage](http://oi68.tinypic.com/wt7qrq.jpg)


### With new code :

![AfterImage](http://oi68.tinypic.com/2hhd53d.jpg)



Hope this will help !
Thanks :) 